### PR TITLE
Refactored loyalty finder

### DIFF
--- a/lib/banken/loyalty_finder.rb
+++ b/lib/banken/loyalty_finder.rb
@@ -2,10 +2,10 @@ module Banken
   class LoyaltyFinder
     SUFFIX = "Loyalty"
 
-    attr_reader :controller
+    attr_reader :controller_name
 
-    def initialize(controller)
-      @controller = controller.to_s
+    def initialize(controller_name)
+      @controller_name = controller_name.to_s
     end
 
     def loyalty
@@ -15,13 +15,13 @@ module Banken
     end
 
     def loyalty!
-      loyalty || raise(NotDefinedError, "unable to find loyalty `#{loyalty_name}` for `#{controller}`")
+      loyalty || raise(NotDefinedError, "unable to find loyalty `#{loyalty_name}` for `#{controller_name}`")
     end
 
     private
 
       def loyalty_name
-        "#{controller.camelize}#{SUFFIX}"
+        "#{controller_name.camelize}#{SUFFIX}"
       end
   end
 end

--- a/lib/banken/loyalty_finder.rb
+++ b/lib/banken/loyalty_finder.rb
@@ -15,7 +15,6 @@ module Banken
     end
 
     def loyalty!
-      raise NotDefinedError, "unable to find loyalty of nil" unless controller
       loyalty || raise(NotDefinedError, "unable to find loyalty `#{loyalty_name}` for `#{controller}`")
     end
 


### PR DESCRIPTION
1. Finder's controller_name cannot have nil

  On initialize, @controller of ivar is casted to String from any type. So I think that it don't need to guard `nil`.

  ```ruby
  def initialize(controller_name)
    @controller_name = controller_name.to_s
  end
  ```

2. Attribute name to the same name as an argument name

  I think better that attribute name equals as same as argument name. Because it helps us to distinguish String or Class.

  ```ruby
  class << self
    def loyalty!(controller_name, user, record=nil)
      LoyaltyFinder.new(controller_name).loyalty!.new(user, record)
    end
  end
  ```

  ```ruby
  module Banken
    class LoyaltyFinder
      attr_reader :controller_name

      def initialize(controller_name)
        @controller_name = controller_name.to_s
      end
  ```

Would you please review this pull request. Thanks a lot.