### PR TITLE
[Proposal] Directory define banken query methods to the Controller class without creating a loyalty class

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In first, Look this tutorial:
  - [The difference between Banken and Pundit](https://github.com/kyuden/banken/wiki/The-difference-between-Banken-and-Pundit)
  - [The difference between Banken and Pundit (Japanese)](https://github.com/kyuden/banken/wiki/The-difference-between-Banken-and-Pundit-(Japanese))
 
- 
+
 ## Installation
 
 ``` ruby
@@ -406,6 +406,22 @@ class PostsController < ApplicationController
     else
       render :edit
     end
+  end
+end
+```
+
+## Directly define query methods to the Controller
+
+Optionally, You can directly define query methods by `def_banken_query_method_for` to the Controller without creating a loyalty class:
+
+```ruby
+class PostsController < ApplicationController
+  def admin_list
+    authorize!
+  end
+
+  def_banken_query_method_for(:admin_list) do
+    user.admin?
   end
 end
 ```

--- a/lib/banken/loyalty_factory.rb
+++ b/lib/banken/loyalty_factory.rb
@@ -1,0 +1,45 @@
+module Banken
+  class LoyaltyFactory
+    SUFFIX = "Loyalty"
+
+    attr_reader :controller_name, :base_controller_name
+
+    def initialize(controller)
+      @controller_name      = extract_controller_name(controller)
+      @base_controller_name = extract_controller_name(controller.superclass)
+    end
+
+    def create
+      Object.const_set(loyalty_name, loyalty_klass)
+    end
+
+    private
+
+      def extract_controller_name(controller)
+        controller.controller_path if controller.to_s.end_with?("Controller")
+      end
+
+      def loyalty_name
+        "#{controller_name.camelize}#{SUFFIX}"
+      end
+
+      def loyalty_klass
+        if base_controller_name
+          Class.new(base_loyalty)
+        else
+          Class.new do
+            attr_reader :user, :record
+
+            def initialize(user, record)
+              @user = user
+              @record = record
+            end
+          end
+        end
+      end
+
+      def base_loyalty
+        LoyaltyFinder.new(base_controller_name).loyalty!
+      end
+  end
+end

--- a/spec/banken_spec.rb
+++ b/spec/banken_spec.rb
@@ -7,6 +7,7 @@ describe Banken do
   let(:comment) { Comment.new }
   let(:article) { Article.new }
   let(:posts_controller) { PostsController.new(user, { :action => 'update', :controller => 'posts' }) }
+  let(:users_controller) { UsersController.new(user, { :action => 'index', :controller => 'users' }) }
 
   describe ".loyalty!" do
     it "returns an instantiated loyalty given a controller name" do
@@ -32,6 +33,16 @@ describe Banken do
 
     it "throws an exception if the given loyalty can't be found" do
       expect { Banken.loyalty!('articles', user, article) }.to raise_error(Banken::NotDefinedError)
+    end
+  end
+
+  describe ".def_banken_query_method_for" do
+    it "defines banken query method to the loyalty class with the same name as the Controller" do
+      UsersController.def_banken_query_method_for(:index) { true }
+      loyalty = Banken.loyalty!('users', user)
+      expect(loyalty.class.name).to eq 'UsersLoyalty'
+      expect(loyalty.class.superclass.name).to eq 'ApplicationLoyalty'
+      expect(users_controller.authorize!).to be true
     end
   end
 

--- a/spec/support/controllers/application_controller.rb
+++ b/spec/support/controllers/application_controller.rb
@@ -1,0 +1,16 @@
+class ApplicationController
+  include Banken
+
+  attr_accessor :current_user, :params
+
+  def initialize(current_user, params={})
+    @current_user = current_user
+    @params = params
+  end
+
+  class << self
+    def controller_path
+      name.sub(/Controller$/, '').underscore
+    end
+  end
+end

--- a/spec/support/controllers/posts_controller.rb
+++ b/spec/support/controllers/posts_controller.rb
@@ -1,10 +1,1 @@
-class PostsController
-  include Banken
-
-  attr_accessor :current_user, :params
-
-  def initialize(current_user, params={})
-    @current_user = current_user
-    @params = params
-  end
-end
+class PostsController < ApplicationController; end

--- a/spec/support/controllers/users_controller.rb
+++ b/spec/support/controllers/users_controller.rb
@@ -1,0 +1,1 @@
+class UsersController < ApplicationController; end


### PR DESCRIPTION
When the rule is not complicated, It is convenient for us to add query methods directly to the controller class without creating a loyalty class:

```ruby
class WelcomeController < ApplicationController
  def_banken_query_method_for(:index) { user.admin? || user.manager? }

  def index
    @records = Record.all
  end
end
```

Of course, when implementing complex logic that requires unit testing, there is no objection on the approach to implementing loyalty classes. I wanna use this feature, so I've implemented it.

Would you please tell me your opinion.