### PR TITLE
add Readme about How to call loyalty class with namespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ conditionally showing links or buttons in the view:
 <% end %>
 ```
 
+If you are using namespace in your controller and policy,
+you can access the policy passing string like 'admin/posts' as a second argument.
+Below calls Admin::PostsLoyalty.
+
+``` erb
+<% if loyalty(@post, 'admin/posts').update? %>
+  <%= link_to "Edit post", edit_post_path(@post) %>
+<% end %>
+```
+
 ## Ensuring loyalties are used
 
 Banken adds a method called `verify_authorized` to your controllers. This


### PR DESCRIPTION
# WHAT
Add docs about helper method 'loyalty'.
when developer want access a loyalty class with name space, like "Admin::PostsLoyalty"

# WHY
Because I was stuck here for 10min
And I have to look into the source code in the end.