### PR TITLE
Change name `banken_loyalty_authorized` to `banken_authorization_performed?`

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ end
 ```
 
 If you need to perform some more sophisticated logic or you want to raise a custom
-exception you can use the two lower level method `banken_loyalty_authorized?` which
+exception you can use the two lower level method `banken_authorization_performed?` which
 return `true` or `false` depending on whether `authorize!` have been called, respectively.
 
 ## Just plain old Ruby

--- a/lib/banken.rb
+++ b/lib/banken.rb
@@ -67,6 +67,12 @@ module Banken
     !!@_banken_authorization_performed
   end
 
+  # @deprecated Use banken_authorization_performed? instead.
+  def banken_loyalty_authorized?
+    ActiveSupport::Deprecation.warn('banken_loyalty_authorized? is deprecated, use banken_authorization_performed? instead.')
+    banken_authorization_performed?
+  end
+
   private
 
     def banken_action_name

--- a/lib/banken.rb
+++ b/lib/banken.rb
@@ -31,7 +31,7 @@ module Banken
   end
 
   def authorize!(record=nil)
-    @_banken_loyalty_authorized = true
+    @_banken_authorization_performed = true
 
     loyalty = loyalty(record)
     unless loyalty.public_send(banken_query_name)
@@ -56,15 +56,15 @@ module Banken
   end
 
   def skip_authorization
-    @_banken_loyalty_authorized = true
+    @_banken_authorization_performed = true
   end
 
   def verify_authorized
-    raise AuthorizationNotPerformedError unless banken_loyalty_authorized?
+    raise AuthorizationNotPerformedError unless banken_authorization_performed?
   end
 
-  def banken_loyalty_authorized?
-    !!@_banken_loyalty_authorized
+  def banken_authorization_performed?
+    !!@_banken_authorization_performed
   end
 
   private

--- a/spec/banken_spec.rb
+++ b/spec/banken_spec.rb
@@ -46,14 +46,14 @@ describe Banken do
     end
   end
 
-  describe "#banken_loyalty_authorized?" do
+  describe "#banken_authorization_performed?" do
     it "is true when authorized!" do
       posts_controller.authorize!(post)
-      expect(posts_controller.banken_loyalty_authorized?).to be true
+      expect(posts_controller.banken_authorization_performed?).to be true
     end
 
     it "is false when not authorized!" do
-      expect(posts_controller.banken_loyalty_authorized?).to be false
+      expect(posts_controller.banken_authorization_performed?).to be false
     end
   end
 

--- a/spec/banken_spec.rb
+++ b/spec/banken_spec.rb
@@ -46,6 +46,21 @@ describe Banken do
     end
   end
 
+  describe '#banken_loyalty_authorized?' do
+    it "is true when authorized!" do
+      posts_controller.authorize!(post)
+      expect(posts_controller.banken_loyalty_authorized?).to be true
+    end
+
+    it "is false when not authorized!" do
+      expect(posts_controller.banken_loyalty_authorized?).to be false
+    end
+
+    it "outputs deprecation warning" do
+      expect { posts_controller.banken_loyalty_authorized? }.to output(/^DEPRECATION WARNING: banken_loyalty_authorized\? is deprecated, use banken_authorization_performed\? instead\./).to_stderr
+    end
+  end
+
   describe "#banken_authorization_performed?" do
     it "is true when authorized!" do
       posts_controller.authorize!(post)


### PR DESCRIPTION
I think the name `banken_loyalty_authorized` is not really meaningful, so I changed it to `banken_authorization_performed` which expresses the actual behavior.