### PR TITLE
Remove Ruby `2.2.10` from `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 script: "bundle exec rake"
 rvm:
-  - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/
Ruby 2.2 is not supported anymore and tests on TravisCI fails.
I think we should remove Ruby 2.2 from `.travis.yml`