### PR TITLE
permitted_attributes to take param_key into consideration.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
 
   pull_request:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Ruby ${{ matrix.ruby }} x Rails ${{ matrix.rails }}"
+    strategy:
+      matrix:
+        ruby:
+          - 2.3
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
+          - 3.3
+        rails:
+          - '~> 4.0'
+          - '~> 5.0'
+          - '~> 6.0.0'
+          - '~> 6.1.0'
+          - '~> 7.0.0'
+          - '~> 7.1.0'
+        exclude:
+          - ruby: 2.3
+            rails: '~> 6.0.0'
+          - ruby: 2.3
+            rails: '~> 6.1.0'
+          - ruby: 2.3
+            rails: '~> 7.0.0'
+          - ruby: 2.3
+            rails: '~> 7.1.0'
+          - ruby: 2.4
+            rails: '~> 6.0.0'
+          - ruby: 2.4
+            rails: '~> 6.1.0'
+          - ruby: 2.4
+            rails: '~> 7.0.0'
+          - ruby: 2.4
+            rails: '~> 7.1.0'
+          - ruby: 2.5
+            rails: '~> 7.0.0'
+          - ruby: 2.5
+            rails: '~> 7.1.0'
+          - ruby: 2.6
+            rails: '~> 7.0.0'
+          - ruby: 2.6
+            rails: '~> 7.1.0'
+          - ruby: 2.7
+            rails: '~> 4.0'
+          - ruby: 3.0
+            rails: '~> 4.0'
+          - ruby: 3.1
+            rails: '~> 4.0'
+          - ruby: 3.2
+            rails: '~> 4.0'
+          - ruby: 3.3
+            rails: '~> 4.0'
+
+    env:
+      RAILS: ${{ matrix.rails }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - name: Run rspec
+      run: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-sudo: false
-script: "bundle exec rake"
-rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,18 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "activemodel", ">= 3.0.0"
-gem "actionpack", ">= 3.0.0"
+case ENV.fetch('RAILS', 'latest')
+when 'latest'
+  gem 'activemodel'
+  gem 'actionpack'
+when 'head'
+  gem 'activemodel', github: 'rails/rails'
+  gem 'actionpack', github: 'rails/rails'
+else
+  gem 'activemodel', ENV.fetch('RAILS', nil)
+  gem 'actionpack', ENV.fetch('RAILS', nil)
+end
+
 gem "bundler"
 gem "rspec", "~> 3.0"
 gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,11 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem "activemodel", ">= 3.0.0"
+gem "actionpack", ">= 3.0.0"
+gem "bundler", "~> 1.3"
+gem "rspec", "~> 3.0"
+gem "pry"
+gem "rake"
+gem "yard"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem "activemodel", ">= 3.0.0"
 gem "actionpack", ">= 3.0.0"
-gem "bundler", "~> 1.3"
+gem "bundler"
 gem "rspec", "~> 3.0"
 gem "pry"
 gem "rake"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img width="350" src="https://raw.github.com/wiki/kyuden/banken/images/banken.png">
 
-[![Build Status](https://img.shields.io/travis/kyuden/banken/master.svg)](https://travis-ci.org/kyuden/banken)
+![Build Status](https://github.com/kyuden/banken/workflows/CI/badge.svg)
 [![Code Climate](https://codeclimate.com/github/kyuden/banken/badges/gpa.svg)](https://codeclimate.com/github/kyuden/banken)
 [![Gem Version](https://badge.fury.io/rb/banken.svg)](https://badge.fury.io/rb/banken)
 
@@ -17,7 +17,7 @@ In first, Look this tutorial:
  - [The difference between Banken and Pundit](https://github.com/kyuden/banken/wiki/The-difference-between-Banken-and-Pundit)
  - [The difference between Banken and Pundit (Japanese)](https://github.com/kyuden/banken/wiki/The-difference-between-Banken-and-Pundit-(Japanese))
 
- 
+
 ## Installation
 
 ``` ruby

--- a/banken.gemspec
+++ b/banken.gemspec
@@ -19,12 +19,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'activesupport', '>= 3.0.0'
-
-  spec.add_development_dependency "activemodel", ">= 3.0.0"
-  spec.add_development_dependency "actionpack", ">= 3.0.0"
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "yard"
 end

--- a/lib/banken.rb
+++ b/lib/banken.rb
@@ -42,7 +42,8 @@ module Banken
   end
 
   def permitted_attributes(record)
-    name = record.class.to_s.demodulize.underscore
+    name = record.respond_to?(:model_name) && record.model_name.param_key
+    name ||= record.class.to_s.demodulize.underscore
     params.require(name).permit(loyalty(record).permitted_attributes)
   end
 

--- a/spec/banken_spec.rb
+++ b/spec/banken_spec.rb
@@ -141,15 +141,15 @@ describe Banken do
     it "checks loyalty for permitted attributes" do
       params = ActionController::Parameters.new({ controller: 'posts', action: 'update', post: { title: 'Hello', votes: 5, admin: true } })
 
-      expect(PostsController.new(user, params).permitted_attributes(post)).to eq({ 'title' => 'Hello', 'votes' => 5 })
-      expect(PostsController.new(double, params).permitted_attributes(post)).to eq({ 'votes' => 5 })
+      expect(PostsController.new(user, params).permitted_attributes(post).to_h).to eq({ 'title' => 'Hello', 'votes' => 5 })
+      expect(PostsController.new(double, params).permitted_attributes(post).to_h).to eq({ 'votes' => 5 })
     end
 
     it "checks loyalty for permitted attributes by ActiveModel" do
       params = ActionController::Parameters.new({ controller: 'posts/comments', action: 'update', post_comment: { body: 'Hello', published: false, admin: true } })
 
-      expect(Posts::CommentsController.new(user, params).permitted_attributes(comment)).to eq({ 'body' => 'Hello', 'published' => false })
-      expect(Posts::CommentsController.new(double, params).permitted_attributes(comment)).to eq({ 'body' => 'Hello' })
+      expect(Posts::CommentsController.new(user, params).permitted_attributes(comment).to_h).to eq({ 'body' => 'Hello', 'published' => false })
+      expect(Posts::CommentsController.new(double, params).permitted_attributes(comment).to_h).to eq({ 'body' => 'Hello' })
     end
   end
 

--- a/spec/banken_spec.rb
+++ b/spec/banken_spec.rb
@@ -4,7 +4,7 @@ describe Banken do
   let(:user) { double }
   let(:post) { Post.new(user, 1) }
   let(:post2) { Post.new(user, 2) }
-  let(:comment) { Comment.new }
+  let(:comment) { Post::Comment.new(post) }
   let(:article) { Article.new }
   let(:posts_controller) { PostsController.new(user, { :action => 'update', :controller => 'posts' }) }
 
@@ -143,6 +143,13 @@ describe Banken do
 
       expect(PostsController.new(user, params).permitted_attributes(post)).to eq({ 'title' => 'Hello', 'votes' => 5 })
       expect(PostsController.new(double, params).permitted_attributes(post)).to eq({ 'votes' => 5 })
+    end
+
+    it "checks loyalty for permitted attributes by ActiveModel" do
+      params = ActionController::Parameters.new({ controller: 'posts/comments', action: 'update', post_comment: { body: 'Hello', published: false, admin: true } })
+
+      expect(Posts::CommentsController.new(user, params).permitted_attributes(comment)).to eq({ 'body' => 'Hello', 'published' => false })
+      expect(Posts::CommentsController.new(double, params).permitted_attributes(comment)).to eq({ 'body' => 'Hello' })
     end
   end
 

--- a/spec/support/controllers/posts/comments_controller.rb
+++ b/spec/support/controllers/posts/comments_controller.rb
@@ -1,0 +1,12 @@
+module Posts
+  class CommentsController
+    include Banken
+
+    attr_accessor :current_user, :params
+
+    def initialize(current_user, params={})
+      @current_user = current_user
+      @params = params
+    end
+  end
+end

--- a/spec/support/loyalties/posts/comments_loyalty.rb
+++ b/spec/support/loyalties/posts/comments_loyalty.rb
@@ -1,0 +1,21 @@
+require_relative '../application_loyalty'
+
+module Posts
+  class CommentsLoyalty < ApplicationLoyalty
+    def update?
+      record.post.user == user
+    end
+
+    def show?
+      true
+    end
+
+    def permitted_attributes
+      if record.post.user == user
+        [:body, :published]
+      else
+        [:body]
+      end
+    end
+  end
+end

--- a/spec/support/models/post.rb
+++ b/spec/support/models/post.rb
@@ -4,4 +4,12 @@ class Post < Struct.new(:user, :id)
   end
   def to_s; "Post"; end
   def inspect; "#<Post>"; end
+
+  class Comment < Struct.new(:post, :body, :published)
+    def to_s; "Post::Comment"; end
+    def inspect; "#<Post::Comment>"; end
+    def model_name
+      Struct.new(:param_key).new('post_comment')
+    end
+  end
 end


### PR DESCRIPTION
I really like permitted_attributes and would like to apply it to many cases, but I am having a little trouble with it.
It is not possible to determine the namespace-aware scope name from a nested model name such as Admin::User.

    Admin::User -> :user

This pull request solves that problem.

    Admin::User -> :admin_user

Specifically, for objects that respond to model_name (assuming ActiveRecord::Base, etc.), we'll apply model_name.param_key This is similar to how form_with in Rails determines the scope.
See https://github.com/rails/rails/blob/main/actionview/lib/action_view/helpers/form_helper.rb#L750